### PR TITLE
Fix RGB scrollbar values persisting across item selections

### DIFF
--- a/game_engine/ui/designer.py
+++ b/game_engine/ui/designer.py
@@ -422,6 +422,12 @@ pygame.quit()"""
                                 self.objectHealth = 100  # Ayarlanacak
                                 self.objectScale = 1  # Ayarlanacak
                                 self.objectAnims = []
+                            # Reset RGB scrollbar state so stale values from
+                            # the previous item are not carried over.
+                            for _rgb_key in ("R", "G", "B"):
+                                if _rgb_key in UI.memory:
+                                    UI.memory[_rgb_key]["scroll"] = [0, 0]
+                                    UI.memory[_rgb_key]["condition"] = 0
                             self.tile_info_bool = True
                         else:
                             if event.pos[0] < self.screen.get_size()[0] - 200 or event.pos[1] > 350:


### PR DESCRIPTION
## Summary
- Fixes bug where R/G/B light editor scrollbar values from a previously selected item persist when selecting a new item
- `UI.memory` entries for scrollbar windows are only initialized once (on first render), so the scroll position and condition carry over between item changes
- Resets `scroll` and `condition` for R, G, B memory keys when a new item is selected in the designer

## Root Cause
In `designer.py`, when `UI.window("R", ...)` is called, the memory entry is created only if it doesn't already exist (guarded by `KeyError` on `cls.memory[name]["surface"]`). The `"scroll"` list and `"condition"` value therefore persist across item selections, causing the color preview to show stale RGB values from the previous item.

## Test plan
- [ ] Open the designer, select an item, open the light editor, move the RGB sliders
- [ ] Select a different item and reopen the light editor — sliders should now reset to 0

Fixes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)