### PR TITLE
Fixes 26 : add modulable size light and display the value of the size and the colors in the light editor

### DIFF
--- a/game_engine/core/ui.py
+++ b/game_engine/core/ui.py
@@ -287,7 +287,8 @@ class UI:
                     if key == pygame.K_s and pygame.key.get_mods() & pygame.KMOD_SHIFT:
                         name = cls.memory["info_name"]["text"]["name"]
                         with open(f"items/{name}.py", "w", encoding="utf-8") as file:
-                            file.write(f"""
+                            file.write(
+                                f"""
 # ruff: noqa
 import repackage
 
@@ -302,7 +303,8 @@ self = Temp("{name}")
 def update(tiles):
     exec('''
 {_memory["text"]["name"]}
-    ''')""")
+    ''')"""
+                            )
 
                             with open("items/info.json", "r") as json_file:
                                 data = json.loads(json_file.read())

--- a/game_engine/ui/designer.py
+++ b/game_engine/ui/designer.py
@@ -290,9 +290,11 @@ class Window:
 
         os.makedirs(f"{publish_dest}/ui/images", exist_ok=True)
         with open(f"{publish_dest}/ui/images/init.py", "w", encoding="utf-8") as file:
-            file.write("""
+            file.write(
+                """
 class image_:
-    pass""")
+    pass"""
+            )
 
         os.makedirs(f"{publish_dest}/game_engine/items", exist_ok=True)
         shutil.copy("../game_engine/items/template.py", f"{publish_dest}/game_engine/items")
@@ -301,7 +303,8 @@ class image_:
         shutil.copy("../game_engine/ui/images/light.png", f"{publish_dest}/game_engine/images")
 
         with open(f"{publish_dest}/main.py", "w", encoding="utf-8") as file:
-            file.write("""
+            file.write(
+                """
 import pygame
 
 timer = pygame.time.Clock()
@@ -326,7 +329,8 @@ while command:
 
     timer.tick(60) #FPS Limit
 
-pygame.quit()""")
+pygame.quit()"""
+            )
 
     # -Display----------------------------------------------------------------------------------------------
     def update(self):


### PR DESCRIPTION
I wasn't entirely satisfied with my commit so I decided to add some enhancement that seemed needed like :

- Modulable light size
- Display the value of the light colors and the size and we changed it

<img width="340" height="252" alt="image" src="https://github.com/user-attachments/assets/8cab74ca-999f-432b-bbc8-5f20aec88c54" />

linked to #23 and #6 
