### PR TITLE
rgb-fix

### DIFF
--- a/game_engine/ui/designer.py
+++ b/game_engine/ui/designer.py
@@ -290,9 +290,11 @@ class Window:
 
         os.makedirs(f"{publish_dest}/ui/images", exist_ok=True)
         with open(f"{publish_dest}/ui/images/init.py", "w", encoding="utf-8") as file:
-            file.write("""
+            file.write(
+                """
 class image_:
-    pass""")
+    pass"""
+            )
 
         os.makedirs(f"{publish_dest}/game_engine/items", exist_ok=True)
         shutil.copy("../game_engine/items/template.py", f"{publish_dest}/game_engine/items")
@@ -301,7 +303,8 @@ class image_:
         shutil.copy("../game_engine/ui/images/light.png", f"{publish_dest}/game_engine/images")
 
         with open(f"{publish_dest}/main.py", "w", encoding="utf-8") as file:
-            file.write("""
+            file.write(
+                """
 import pygame
 
 timer = pygame.time.Clock()
@@ -326,7 +329,8 @@ while command:
 
     timer.tick(60) #FPS Limit
 
-pygame.quit()""")
+pygame.quit()"""
+            )
 
     # -Display----------------------------------------------------------------------------------------------
     def update(self):
@@ -428,7 +432,7 @@ pygame.quit()""")
                                 if _rgb_key in UI.memory:
                                     UI.memory[_rgb_key]["scroll"] = [0, 0]
                                     UI.memory[_rgb_key]["condition"] = 0
-                            
+
                             self.tile_info_bool = True
                         else:
                             if event.pos[0] < self.screen.get_size()[0] - 200 or event.pos[1] > 350:

--- a/game_engine/ui/designer.py
+++ b/game_engine/ui/designer.py
@@ -290,11 +290,9 @@ class Window:
 
         os.makedirs(f"{publish_dest}/ui/images", exist_ok=True)
         with open(f"{publish_dest}/ui/images/init.py", "w", encoding="utf-8") as file:
-            file.write(
-                """
+            file.write("""
 class image_:
-    pass"""
-            )
+    pass""")
 
         os.makedirs(f"{publish_dest}/game_engine/items", exist_ok=True)
         shutil.copy("../game_engine/items/template.py", f"{publish_dest}/game_engine/items")
@@ -303,8 +301,7 @@ class image_:
         shutil.copy("../game_engine/ui/images/light.png", f"{publish_dest}/game_engine/images")
 
         with open(f"{publish_dest}/main.py", "w", encoding="utf-8") as file:
-            file.write(
-                """
+            file.write("""
 import pygame
 
 timer = pygame.time.Clock()
@@ -329,8 +326,7 @@ while command:
 
     timer.tick(60) #FPS Limit
 
-pygame.quit()"""
-            )
+pygame.quit()""")
 
     # -Display----------------------------------------------------------------------------------------------
     def update(self):
@@ -425,6 +421,14 @@ pygame.quit()"""
                                 self.objectHealth = 100  # Ayarlanacak
                                 self.objectScale = 1  # Ayarlanacak
                                 self.objectAnims = []
+
+                            # Reset RGB scrollbar state so stale values from
+                            # the previous item are not carried over.
+                            for _rgb_key in ("R", "G", "B"):
+                                if _rgb_key in UI.memory:
+                                    UI.memory[_rgb_key]["scroll"] = [0, 0]
+                                    UI.memory[_rgb_key]["condition"] = 0
+                            
                             self.tile_info_bool = True
                         else:
                             if event.pos[0] < self.screen.get_size()[0] - 200 or event.pos[1] > 350:
@@ -778,8 +782,6 @@ Animation Amount: {}""".format(
         # ------------------------------------------------------------------------------------------------------------
 
         # -Light Editor Window----------------------------------------------------------------------------------------
-        # ------------------------------------------------------------------------------------------------------------
-
         elif self.light_editor_bool:
             coords = list(self.unconverted_objectCoords)
             coords[0] += self.objectSize[0] * self.win_scale


### PR DESCRIPTION
Cleared cash data `["scroll"]` and `["condition"]` from UI.memory. It indexes to 0 which will fix RGB value persistence. 

Fixes #24.