### PR TITLE
Issue 4 - Fixing offset issue when drag and dropping

### DIFF
--- a/game_engine/ui/designer.py
+++ b/game_engine/ui/designer.py
@@ -934,9 +934,7 @@ Animation Amount: {}""".format(
                 np.array(self.tools_dict[self.drag_and_dropping.item_coords]["image"].get_size()) * self.win_scale
             )
             scaled_img = pygame.transform.scale(img, scale_ratio)
-            coords = tuple(
-                np.array(self.cursor_pos) - (np.array(self.drag_and_dropping.item_collision_coords) * self.win_scale)
-            )
+            coords = self.cursor_pos
             self.screen.blit(scaled_img, coords)
         # ------------------------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
Now in designer mod the assets you want to place are at the same position with no offset, the asset is not centered with the cursor though but set on the top left of the asset's image.

Edit done : 
In file "game_engine/ui/designer.py", i removed the tuple for the coordonates and changed it to be on the cursor position.