### PR TITLE
Tint rendered lights with light_color

### DIFF
--- a/game_engine/core/light.py
+++ b/game_engine/core/light.py
@@ -32,8 +32,9 @@ class Light:
     `render`
     """
 
-    def __init__(self, size) -> None:
+    def __init__(self, size, light_color=(255, 255, 255)) -> None:
         self.width, self.height = size
+        self.light_color = light_color
         self.darkness = pygame.Surface(size, pygame.SRCALPHA)
         try:
             image = pygame.image.load("../game_engine/ui/images/light.png").convert_alpha()
@@ -232,6 +233,7 @@ class Light:
                 mask_surf = pygame.transform.smoothscale(small, (self.width, self.height))
 
             light_cut = self.light_image.copy()
+            light_cut.fill(self.light_color, special_flags=pygame.BLEND_RGBA_MULT)
             light_cut.blit(mask_surf, (0, 0), special_flags=pygame.BLEND_RGBA_MULT)
 
             self.darkness.fill((0, 0, 0, 0))

--- a/game_engine/items/template.py
+++ b/game_engine/items/template.py
@@ -167,8 +167,11 @@ class Temp:
                     pass
 
             if self.lights:
+                light_color = self.lights.get("RGB", (255, 255, 255))
                 if self.light_system is None:
-                    self.light_system = Light((self.lights["size"], self.lights["size"]))
+                    self.light_system = Light((self.lights["size"], self.lights["size"]), light_color)
+                else:
+                    self.light_system.light_color = light_color
 
                 l_c_x, l_c_y = self.lights["coords"]
                 size_mid = self.lights["size"] // 2

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -1,0 +1,28 @@
+# ruff: noqa: E402,I001
+import os
+
+
+os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
+
+import pygame
+
+from game_engine.core.light import Light
+
+
+def make_surface(size=(8, 8), color=(255, 255, 255, 255)):
+    surface = pygame.Surface(size, pygame.SRCALPHA)
+    surface.fill(color)
+    return surface
+
+
+def test_render_tints_light_with_light_color(monkeypatch):
+    pygame.display.init()
+    pygame.display.set_mode((1, 1))
+    monkeypatch.setattr(pygame.image, "load", lambda path: make_surface())
+
+    light = Light((8, 8), light_color=(255, 0, 0))
+    light.visibility_polygon = lambda light_pos, segments: [(0, 0), (7, 0), (7, 7), (0, 7)]
+
+    result = light.render((0, 0), [((0, 0), make_surface((1, 1)))])
+
+    assert result.get_at((4, 4)) == (255, 0, 0, 255)

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -26,3 +26,48 @@ def test_render_tints_light_with_light_color(monkeypatch):
     result = light.render((0, 0), [((0, 0), make_surface((1, 1)))])
 
     assert result.get_at((4, 4)) == (255, 0, 0, 255)
+
+
+def test_template_uses_configured_light_rgb(monkeypatch, tmp_path):
+    pygame.display.init()
+    pygame.display.set_mode((1, 1))
+    from game_engine.items import template
+
+    items_dir = tmp_path / "items"
+    items_dir.mkdir()
+    (items_dir / "info.json").write_text(
+        """
+        {
+          "streetLight": {
+            "sizes": [8, 8],
+            "coords": [10, 20],
+            "health": 100,
+            "scale": 1,
+            "animations": [],
+            "image": "street-light.png",
+            "lights": {"coords": [4, 4], "size": 16, "RGB": [150, 30, 10]}
+          }
+        }
+        """,
+        encoding="utf-8",
+    )
+
+    created_lights = []
+
+    class FakeLight:
+        def __init__(self, size, light_color=(255, 255, 255)):
+            self.light_color = tuple(light_color)
+            created_lights.append((size, self.light_color))
+
+        def render(self, light_pos, items):
+            return make_surface((16, 16), (*self.light_color, 255))
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(template.pygame.image, "load", lambda path: make_surface())
+    monkeypatch.setattr(template, "Light", FakeLight)
+    monkeypatch.setattr(template, "ITEMS", {})
+
+    item = template.Temp("streetLight")
+    item.decorate(lambda tiles: None)({})
+
+    assert created_lights == [((16, 16), (150, 30, 10))]


### PR DESCRIPTION
## Summary
- Add a `light_color` argument to `Light` with the current white behavior as the default.
- Apply the configured color tint before masking the light texture during rendering.
- Add a headless Pygame regression test for colored light rendering.

Fixes #33.

## Validation
- `PYTHONPATH=. uv run --no-project --with pytest --with pygame==2.6.1 pytest -q tests/test_light.py`
- `PYTHONPATH=. uv run --no-project --with ruff ruff check game_engine/core/light.py tests/test_light.py`
- `python3 -m py_compile game_engine/core/light.py tests/test_light.py`
- `git diff --check`