### PR TITLE
Allow item selection in draw mode

### DIFF
--- a/game_engine/ui/designer.py
+++ b/game_engine/ui/designer.py
@@ -395,7 +395,7 @@ pygame.quit()"""
                 if e_button == 1:
                     self.cursor = IMAGES.normalCursorL
 
-                    if self.tileset_choosing:
+                    if self.tileset_choosing and not cursor_interaction:
                         self.polygon_rects.append(self.cursor_pos)
                     elif self.is_hitbox_on:
                         self.rects = []


### PR DESCRIPTION
## Summary
- allow left-clicking an existing scene item to open selection/info while a tileset is active
- keep drawing behavior for empty clicks in tileset mode

Fixes #31

## Validation
- `python3 -m compileall -q game_engine tests`
- `git diff --check`

`python3 -m pytest -q` could not run locally because `pytest` is not installed in the checkout environment.